### PR TITLE
fix: $SL_2(F_3)/Z(SL_2(F_3))$ should be isomorphic to $A_4$.

### DIFF
--- a/FATEH/12.lean
+++ b/FATEH/12.lean
@@ -3,9 +3,8 @@ import Mathlib
 open MatrixGroups
 
 /--
-Prove that \( SL_2(\mathbb{F}_3) / Z(SL_2(\mathbb{F}_3)) < A_4 \).
+Prove that \( SL_2(\mathbb{F}_3) / Z(SL_2(\mathbb{F}_3)) \cong A_4 \).
 -/
 theorem exists_sl_quot_center_monoidHom_alternatingGroup :
-    ∃ φ : SL(2,ZMod 3) ⧸ Subgroup.center SL(2,ZMod 3) →* alternatingGroup (Fin 4),
-    Function.Injective φ := by
+    Nonempty (SL(2,ZMod 3) ⧸ Subgroup.center SL(2,ZMod 3) ≃* alternatingGroup (Fin 4)) := by
   sorry


### PR DESCRIPTION
Usually, $H < G$ indicates that $H$ is a proper subgroup of $G$.
Here, $SL_2(F_3)/Z(SL_2(F_3))$ should be isomorphic to $A_4$ which can be found at [wikipedia](https://en.wikipedia.org/wiki/Projective_linear_group#Exceptional_isomorphisms).
Hence I change `<` to `\congr` in the comment and use `≃*` instead of `→*` in the formal statement.